### PR TITLE
Removed ESIK_Result parameter from the delegate on SIK_JoinLobby_AsyncFunction

### DIFF
--- a/Source/SteamIntegrationKit/Functions/Matchmaking/SIK_JoinLobby_AsyncFunction.cpp
+++ b/Source/SteamIntegrationKit/Functions/Matchmaking/SIK_JoinLobby_AsyncFunction.cpp
@@ -19,19 +19,18 @@ void USIK_JoinLobby_AsyncFunction::OnLobbyEnter(LobbyEnter_t* LobbyEnter, bool b
 	{
 		if(bIOFailure)
 		{
-			OnFailure.Broadcast(ESIK_Result::ResultFail, false, ESIK_ChatRoomEnterResponse::None);
+			OnFailure.Broadcast(false, ESIK_ChatRoomEnterResponse::ChatRoomEnterResponseError);
 		}
 		else
 		{
 			TEnumAsByte<ESIK_ChatRoomEnterResponse> ChatRoomEnterResponse = static_cast<ESIK_ChatRoomEnterResponse>(Param.m_EChatRoomEnterResponse);
-			TEnumAsByte<ESIK_Result> Result = static_cast<ESIK_Result>(Param.m_EChatRoomEnterResponse);
 			if(Param.m_EChatRoomEnterResponse == k_EChatRoomEnterResponseSuccess)
 			{
-				OnSuccess.Broadcast(Result, Param.m_bLocked, ChatRoomEnterResponse);
+				OnSuccess.Broadcast(Param.m_bLocked, ChatRoomEnterResponse);
 			}
 			else
 			{
-				OnFailure.Broadcast(ESIK_Result::ResultFail, false, ChatRoomEnterResponse);
+				OnFailure.Broadcast(false, ChatRoomEnterResponse);
 			}
 		}
 	});
@@ -45,7 +44,7 @@ void USIK_JoinLobby_AsyncFunction::Activate()
 	Super::Activate();
 	if(!SteamMatchmaking())
 	{
-		OnFailure.Broadcast(ESIK_Result::ResultFail, false, ESIK_ChatRoomEnterResponse::None);
+		OnFailure.Broadcast(false, ESIK_ChatRoomEnterResponse::ChatRoomEnterResponseError);
 		SetReadyToDestroy();
 		MarkAsGarbage();
 		return;
@@ -53,7 +52,7 @@ void USIK_JoinLobby_AsyncFunction::Activate()
 	CallbackHandle = SteamMatchmaking()->JoinLobby(Var_LobbyId.GetSteamID());
 	if(CallbackHandle == k_uAPICallInvalid)
 	{
-		OnFailure.Broadcast(ESIK_Result::ResultFail, false, ESIK_ChatRoomEnterResponse::None);
+		OnFailure.Broadcast(false, ESIK_ChatRoomEnterResponse::ChatRoomEnterResponseError);
 		SetReadyToDestroy();
 		MarkAsGarbage();
 		return;

--- a/Source/SteamIntegrationKit/Functions/Matchmaking/SIK_JoinLobby_AsyncFunction.h
+++ b/Source/SteamIntegrationKit/Functions/Matchmaking/SIK_JoinLobby_AsyncFunction.h
@@ -18,7 +18,7 @@ THIRD_PARTY_INCLUDES_END
 #include "Kismet/BlueprintAsyncActionBase.h"
 #include "SIK_JoinLobby_AsyncFunction.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FOnJoinLobby, TEnumAsByte<ESIK_Result>, Result, bool, bLocked, TEnumAsByte<ESIK_ChatRoomEnterResponse>, ChatRoomEnterResponse);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FOnJoinLobby, bool, bLocked, TEnumAsByte<ESIK_ChatRoomEnterResponse>, ChatRoomEnterResponse);
 UCLASS()
 class STEAMINTEGRATIONKIT_API USIK_JoinLobby_AsyncFunction : public UBlueprintAsyncActionBase
 {


### PR DESCRIPTION
Removed casting from an EChatRoomEnterResponse to an ESIK_Result and broadcasting that value, which would have unintended consequences if someone tried to use that value. In fact, the LobbyEnter_t callback doesn't even have an EResult property, so I removed it from the delegate altogether.

A good replacement would be to broadcast the Param.m_ulSteamIDLobby of the lobby, which would provide an easy way to see if the callback had a bad response (SteamId would be 0 in this case).