### PR TITLE
Update SIK_SessionsSubsystem.cpp

### DIFF
--- a/Source/SteamIntegrationKit/Functions/Sessions/SIK_SessionsSubsystem.cpp
+++ b/Source/SteamIntegrationKit/Functions/Sessions/SIK_SessionsSubsystem.cpp
@@ -58,17 +58,24 @@ TArray<FSIK_CurrentSessionInfo> USIK_SessionsSubsystem::GetAllJoinedSessionsAndL
 		}
 		if(	IOnlineSubsystem* OnlineSub = IOnlineSubsystem::Get())
 		{
-			if (FOnlineSubsystemSteam* SteamRef = static_cast<FOnlineSubsystemSteam*>(OnlineSub))
+			if(OnlineSub->GetSubsystemName() == STEAM_SUBSYSTEM)
 			{
-				if(FOnlineSessionSteamPtr SteamSessionPtr = StaticCastSharedPtr<FOnlineSessionSteam>(SteamRef->GetSessionInterface()))
+				if (FOnlineSubsystemSteam* SteamRef = static_cast<FOnlineSubsystemSteam*>(OnlineSub))
 				{
-					TArray<FSIK_CurrentSessionInfo> SessionNames;
-					for(auto& SessionEntry : SteamSessionPtr->Sessions)
+					if(FOnlineSessionSteamPtr SteamSessionPtr = StaticCastSharedPtr<FOnlineSessionSteam>(SteamRef->GetSessionInterface()))
 					{
-						SessionNames.Add(FSIK_CurrentSessionInfo(SessionEntry.SessionName.ToString(), SessionEntry.SessionInfo.Get()->ToString()));
+						TArray<FSIK_CurrentSessionInfo> SessionNames;
+						for(auto& SessionEntry : SteamSessionPtr->Sessions)
+						{
+							SessionNames.Add(FSIK_CurrentSessionInfo(SessionEntry.SessionName.ToString(), SessionEntry.SessionInfo.Get()->ToString()));
+						}
+						return SessionNames;
 					}
-					return SessionNames;
 				}
+			}
+			else
+			{
+				UE_LOG_ONLINE_SESSION(Error, TEXT("SIK_SessionsSubsystem: Online Subsystem Steam is not active. GetAllJoinedSessionsAndLobbies cannot be used in editor or with another online subsystem."));
 			}
 		}
 	}


### PR DESCRIPTION
Update SIK_SessionsSubsystem.cpp to protect against crashes in editor when calling GetAllJoinedSessionsAndLobbies.

Encountered when validating there not being any active session or lobby when creating a session in blueprints and then running the game in editor. This prints out an error to notify that the function will not work with another subsystem or in editor.