### PR TITLE
set bUseEngineSteam to true by default

### DIFF
--- a/Source/SteamIntegrationKit/SteamIntegrationKit.Build.cs
+++ b/Source/SteamIntegrationKit/SteamIntegrationKit.Build.cs
@@ -10,7 +10,7 @@ public class SteamIntegrationKit : ModuleRules
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 		
 		//Always change this to true if you want to use the engine steam subsystem which you would need normally for using the Github version of the plugin
-		bool bUseEngineSteam = false;
+		bool bUseEngineSteam = true;
 		
 		PublicIncludePaths.AddRange(
 			new string[] {


### PR DESCRIPTION
For an open-source version of this plugin, bUseEngineSteam should be true by default
Otherwise, it crashes with an error that says that SteamSdk is unavailable
This change might be overridden by the private repo syncer, so I guess you might need to make some adjustments there as well.